### PR TITLE
Fix for various small bugs due to refactoring of MenuSongSelection an…

### DIFF
--- a/src/arc/NoteMod.as
+++ b/src/arc/NoteMod.as
@@ -191,6 +191,9 @@ package arc
 
         public function transformTotalNotes():int
         {
+            if (!notes)
+                return 0;
+
             if (modIsolation)
             {
                 if (options.isolationLength > 0)
@@ -207,7 +210,7 @@ package arc
 
         public function transformSongLength():Number
         {
-            if (notes.length <= 0)
+            if (!notes || notes.length <= 0)
                 return 0;
 
             var firstNote:Note;

--- a/src/classes/Box.as
+++ b/src/classes/Box.as
@@ -147,10 +147,20 @@ package classes
             draw();
         }
 
+        public function get color():uint
+        {
+            return BOX_COLOR;
+        }
+
         public function set borderColor(val:uint):void
         {
             BORDER_COLOR = val;
             draw();
+        }
+
+        public function get borderColor():uint
+        {
+            return BORDER_COLOR;
         }
 
         public function set normalAlpha(val:Number):void
@@ -159,10 +169,20 @@ package classes
             draw();
         }
 
+        public function get normalAlpha():Number
+        {
+            return BOX_ALPHA;
+        }
+
         public function set activeAlpha(val:Number):void
         {
             BOX_ALPHA_ACTIVE = val;
             draw();
+        }
+
+        public function get activeAlpha():Number
+        {
+            return BOX_ALPHA_ACTIVE;
         }
 
         public function set borderAlpha(val:Number):void
@@ -172,10 +192,20 @@ package classes
             draw();
         }
 
+        public function get borderAlpha():Number
+        {
+            return BORDER_ALPHA;
+        }
+
         public function set borderActiveAlpha(val:Number):void
         {
             BORDER_ALPHA_ACTIVE = val;
             draw();
+        }
+
+        public function get borderActiveAlpha():Number
+        {
+            return BORDER_ALPHA_ACTIVE;
         }
     }
 }

--- a/src/classes/chart/Song.as
+++ b/src/classes/chart/Song.as
@@ -641,7 +641,7 @@ package classes.chart
                 return noteMod.transformSongLength();
             }
 
-            if (!chart.Notes)
+            if (!chart.Notes || chart.Notes.length <= 0)
             {
                 return 0;
             }

--- a/src/game/GamePlay.as
+++ b/src/game/GamePlay.as
@@ -306,6 +306,16 @@ package game
                     "restarts": 0,
                     "last_hit": null};
 
+            // Set Defaults for Editor Mode
+            if (options.isEditor)
+            {
+                SOCKET_SONG_MESSAGE["song"]["name"] = "Editor Mode";
+                SOCKET_SONG_MESSAGE["song"]["author"] = "rCubed Engine";
+                SOCKET_SONG_MESSAGE["song"]["difficulty"] = 0;
+                SOCKET_SONG_MESSAGE["song"]["time"] = "10:00";
+                SOCKET_SONG_MESSAGE["song"]["time_seconds"] = 600;
+            }
+
             // Init Game
             initUI();
             initVars();

--- a/src/popups/PopupCustomNoteskin.as
+++ b/src/popups/PopupCustomNoteskin.as
@@ -246,8 +246,8 @@ package popups
         {
             for (var b:int = 0; b < note_colors_btns.length; b++)
             {
-                note_colors_btns[b].alpha = active_color == note_colors_btns[b].color ? 1 : 0.75;
-                note_colors_btns[b].boxColor = active_color == note_colors_btns[b].color ? 0x00FF00 : 0xFFFFFF;
+                note_colors_btns[b].alpha = active_color == note_colors_btns[b].note_color ? 1 : 0.75;
+                note_colors_btns[b].boxColor = active_color == note_colors_btns[b].note_color ? 0x00FF00 : 0xFFFFFF;
             }
 
             var c:BoxText;
@@ -457,7 +457,7 @@ package popups
             }
             else if (e.target.hasOwnProperty("note_color"))
             {
-                active_color = e.target.color;
+                active_color = e.target.note_color;
                 updateDirections();
                 return;
             }


### PR DESCRIPTION
…d Box classes. (#187)

* Add getters for all setters to Box

* Fix for Song Length when chart has 0 notes.

Fixes a null crash.

* Set default song data for editor mode on WebSockets.

Data returned before-hand is undefined for the default displayed data for the overlay.

* Fix PopupCustomNoteskin variable rename.

These were missed in the Box refactor.

* Fix possible null access on NoteMod transform for null or empty charts.